### PR TITLE
Added normal2, a function to compute normals on degenerate beziers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ import { toPowerBasisDdWithRunningError } from './to-power-basis/to-power-basis/
 import { toPowerBasisErrorCounters } from './to-power-basis/to-power-basis/to-power-basis-error-counters.js';
 import { toPowerBasis_1stDerivativeErrorCounters } from './to-power-basis/to-power-basis-1st-derivative/to-power-basis-1st-derivative-error-counters.js';
 import { normal } from './local-properties-at-t/normal/normal.js';
+import { normal2 } from './local-properties-at-t/normal/normal2.js';
 import { bezierBezierIntersection } from './intersection/bezier-bezier-intersection/bezier-bezier-intersection.js';
 import { toCubic } from './transformation/degree-or-type/to-cubic.js';
 import { κ, curvature } from './local-properties-at-t/curvature.js';
@@ -182,6 +183,7 @@ export {
 	ddCurvature,
 	tangent,
 	normal,
+	normal2,
 
 	getTAtLength,
 

--- a/src/local-properties-at-t/normal/normal2.ts
+++ b/src/local-properties-at-t/normal/normal2.ts
@@ -1,0 +1,88 @@
+import { normal } from "./normal.ts";
+import { fromTo as fromToVec } from "flo-vector2d";
+import { fromTo as fromToBezier } from "../../split/from-to.js";
+
+/**
+ * Returns a normal vector (not necessarily of unit length) of a bezier curve
+ * at a specific given parameter value `t` by simply taking the `tangent` at
+ * that point and rotating it by 90 degrees.
+ *
+ * * uses double precision calculations internally
+ *
+ * @param ps a linear, quadratic or cubic bezier curve given by its ordered
+ * control points, e.g. `[[0,0],[1,1],[2,1],[2,0]]`
+ * @param t the parameter value where the normal should be evaluated
+ *
+ * @doc mdx
+ */
+function normal2(ps: number[][], t: number): number[] {
+  const n = normal(ps, t);
+
+  if (ps.length < 3 || n[0] !== 0 || n[1] !== 0) {
+    // Non-degenerate cases
+    return n;
+  }
+
+  if (ps.length === 4) {
+    // Degenerate cases
+
+    const [[x0, y0], [x1, y1], [x2, y2], [x3, y3]] = ps;
+
+    if (x0 === x1 && y0 === y1) {
+      // Points 0 and 1 coincide
+      if (x1 !== x2 || y1 !== y2) {
+        // Point 2 does not coincide
+        const v = fromToVec(ps[0], ps[2]);
+        return [-v[1], v[0]]; // tangent === [v[0], v[1]]
+      }
+
+      // Point 2 also coincides. Now, only return a normal if point 3 does not coincide.
+      if (x2 !== x3 || y2 !== y3) {
+        // Point 3 does not coincide
+        const v = fromToVec(ps[0], ps[3]);
+        return [-v[1], v[0]]; // tangent === [v[0], v[1]]
+      }
+
+      // All four points coincide. No normal possible.
+      return [0, 0];
+    }
+
+    if (x2 === x3 && y2 === y3) {
+      // Point 3 and 2 coincide
+      if (x2 !== x1 || y2 !== y1) {
+        // Point 1 does not coincide
+        const v = fromToVec(ps[1], ps[3]);
+        return [-v[1], v[0]]; // tangent === [v[0], v[1]]
+      }
+
+      // Point 1 also coincides. Now, only return a normal if point 0 does not coincide.
+      if (x1 !== x0 || y1 !== y0) {
+        // Point 0 does not coincide.
+        const v = fromToVec(ps[0], ps[3]);
+        return [-v[1], v[0]]; // tangent === [v[0], v[1]]
+      }
+
+      // Case that all four points coincide is already handled before.
+    }
+
+    // An interior cusp is the only remaining cause of the degenerate normal
+    // Split curve at the cusp
+    const ps_ = fromToBezier(ps, t, 1);
+    const v = fromToVec(ps_[0], ps_[2]);
+
+    return [-v[1], v[0]]; // tangent === [v[0], v[1]]
+  }
+
+  if (ps.length === 3) {
+    const [[x0, y0], [x1, y1], [x2, y2]] = ps;
+    if (x0 !== x2 || y0 !== y2) {
+      // Points 0 and 1, or points 1 and 2 coincide, but not all three
+      const v = fromToVec(ps[0], ps[2]);
+      return [-v[1], v[0]]; // tangent === [v[0], v[1]]
+    }
+  }
+
+  return [0, 0]; // All points coincident - no normal possible
+}
+
+export { normal2 };

--- a/test/local-properties-at-t/normal/normal2.spec.ts
+++ b/test/local-properties-at-t/normal/normal2.spec.ts
@@ -1,0 +1,99 @@
+import { assert, expect, use } from "chai";
+import { describe } from "mocha";
+import {
+  generateCuspAtHalf3,
+  normal,
+  normal2,
+  tangent,
+} from "../../../src/index.js";
+import { nearly } from "../../helpers/chai-extend-nearly.js";
+import { getRandomBezier } from "../../helpers/get-random-bezier.js";
+
+use(nearly);
+
+function degenerate_bezier(ps: number[][], mutation_idx: number) {
+  // The mutation index specifies which case of degenerate bezier the curve will be modified to:
+  // 0. cuspAtStart (point 0 and 1 equal)
+  // 1. cuspAtEnd (point 3 and 2 equal (or 2 and 1 for cubic curves))
+  // 2. cuspAtStartExtreme (point 0, 1, and 2 equal)
+  // 3. cuspAtEndExtreme (point 3, 2 and 1 equal)
+  // 4. selfOverlapping (points 0 and 1 equal, and points 2 and 3 equal)
+  // 5. allCoincident (points 0, 1, 2, and 3 equal (or 0, 1 and 2 for cubic))
+  switch (mutation_idx) {
+    case 0:
+      // cuspAtStart, modify point 1 to be equal to point 0
+      ps[1] = [...ps[0]];
+      break;
+    case 1:
+      // cuspAtEnd, modify second to last point to be equal to last
+      ps[ps.length - 2] = [...ps[ps.length - 1]];
+      break;
+    case 2:
+      // cuspAtStartExtreme, modify points 1 and 2 to be equal to 0
+      ps[1] = [...ps[0]];
+      ps[2] = [...ps[0]];
+      break;
+    case 3:
+      // cuspAtEndExtreme, modify second to last and last point to be equal to third to last.
+      ps[ps.length - 2] = [...ps[ps.length - 3]];
+      ps[ps.length - 1] = [...ps[ps.length - 3]];
+      break;
+    case 4:
+      // selfOverlapping, modify point 1 to be equal to 0, and last to be equal to second to last
+      ps[1] = [...ps[0]];
+      ps[ps.length - 1] = [...ps[ps.length - 2]];
+      break;
+    case 5:
+      // allCoincident, modify all points to be equal
+      ps[1] = [...ps[0]];
+      ps[2] = [...ps[0]];
+      if (ps.length > 3) {
+        ps[3] = [...ps[0]];
+      }
+      break;
+  }
+  return ps;
+}
+
+describe("normal2", function () {
+  it(
+    "it should accurately calculate the normal of some bezier curves, including degenerate bezier curves, at some `t` values",
+    function () {
+      for (let i = 0; i < 10; i++) {
+        for (let order = 2; order <= 3; order++) {
+          for (let mutation = 0; mutation < 5; mutation++) {
+            let ps = getRandomBezier(128, 53)(order as 0 | 1 | 2 | 3)(i);
+            // Make the bezier degenerate
+            ps = degenerate_bezier(ps, mutation);
+
+            let ts = [0, 0.3, 0.9, 1];
+
+            for (let t of ts) {
+              let norm2 = normal2(ps, t);
+              let norm = normal(ps, Math.abs(t - 0.0001));
+
+              // @ts-ignore - otherwise TypeScript gives an error on nearly
+              expect(norm2).to.be.nearly(2 ** 2, norm);
+            }
+          }
+        }
+      }
+
+      // {
+      //   const ps = [[0, 0], [3, 0]];
+      //   const t = 0.5;
+      //   let r = normal(ps, t);
+      //   // for lines there should still be a normal defined
+      //   expect(r).to.eql([-0, 3]);
+      // }
+
+      // {
+      //   const ps = generateCuspAtHalf3([0, 0], [6, 2], [3, 0]);
+      //   const t = 0.5;
+      //   let r = normal(ps, t);
+      //   // at cusp the normal vanishes
+      //   expect(r).to.eql([-0, 0]);
+      // }
+    },
+  );
+});


### PR DESCRIPTION
Test cases are unfinished, but difficult to write without a working typescript setup. Therefore my approach was to just copy over the testcases for the `normal` function and modify that a little, but it turns out to more convoluted that I initially thought, so will have to look into setting up a typescript environment before I can continue further with this.